### PR TITLE
Expose $RAY_PROJECT_PATH to allow using absolute path in config_file.

### DIFF
--- a/src/clients/proxy/ray-proxy.py
+++ b/src/clients/proxy/ray-proxy.py
@@ -670,6 +670,7 @@ class Proxy(QObject):
         os.environ['NSM_CLIENT_ID'] = self.jack_client_name
         os.environ['RAY_CLIENT_ID'] = self.client_id
         os.environ['RAY_SESSION_NAME'] = self.session_name
+        os.environ['RAY_PROJECT_PATH'] = self.project_path
 
         # enable environment vars in config_file
         config_file = os.path.expandvars(self.config_file)


### PR DESCRIPTION
Expose a new environment variable `$RAY_PROJECT_PATH` that allow to pass an absolute path to the client application
`<RAY-PROXY VERSION="0.9.2" arguments="&quot;$CONFIG_FILE&quot;"  executable="musescore"  config_file="$RAY_PROJECT_PATH/$RAY_SESSION_NAME.mscz" ... />`

Relates to  #93 