### PR TITLE
add pyxdg dependency in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,3 +39,4 @@ On Debian and Ubuntu, use these commands to install all build dependencies: <br/
 To run it, you'll additionally need:
 
  - python3-liblo
+ - pyxdg


### PR DESCRIPTION
0a1dd1da5514d47fe1ac4adaef6d872c0e3f6226 introduced a dependency on pyxdg which is easy to overlook, particularly for packagers. This commit remedies that.