### PR TITLE
nsm: send client label instead of session name as nsm display_name

### DIFF
--- a/src/daemon/client.py
+++ b/src/daemon/client.py
@@ -1676,7 +1676,7 @@ class Client(ServerSender, ray.ClientData):
                          % (self.name, client_project_path))
 
         self.send_to_self_address("/nsm/client/open", client_project_path,
-                                  self.session.name, self.jack_client_name)
+                                  self.label, self.jack_client_name)
 
         self.pending_command = ray.Command.OPEN
         
@@ -2271,7 +2271,7 @@ net_session_template:%s""" % (self.ray_net.daemon_url,
             self.session.send_initial_monitor(self.addr)
 
         self.send(src_addr, "/nsm/client/open", client_project_path,
-                  self.session.name, self.jack_client_name)
+                  self.label, self.jack_client_name)
 
         self.pending_command = ray.Command.OPEN
 


### PR DESCRIPTION
Ça semble plus utile pour distinguer plusieurs instances d'une même application lorsque celle-ci utilise l'argument `display_name` de la commande `/nsm/client/open` pour afficher un nom de session dans son interface (par exemple non-mixer-xt).