### PR TITLE
Avoid silent crash if LANG is not defined

### DIFF
--- a/src/daemon/client.py
+++ b/src/daemon/client.py
@@ -391,7 +391,7 @@ class Client(ServerSender, ray.ClientData):
             self.session.end_timer_if_last_expected(self)
 
     def _set_infos_from_desktop_contents(self, contents: str):
-        lang = os.getenv('LANG')
+        lang = os.getenv('LANG', default="C")
         lang_strs = ("[%s]" % lang[0:5], "[%s]" % lang[0:2], "")
         all_data = {'Comment': ['', '', ''],
                     'Name': ['', '', ''],


### PR DESCRIPTION
Without this change, when the locale was not defined correctly (LANG not set), the GUI was running but with no visible jack. The following stack trace was visible in the terminal:
```
Traceback (most recent call last):
  File "/usr/local/share/raysession/src/daemon/file_copier.py", line 142, in _process_finished
    self._next_function(*self._next_args)
  File "/usr/local/share/raysession/src/daemon/session.py", line 1624, in prepare_template_substep1
    self.adjust_files_after_copy(new_session_full_name,
  File "/usr/local/share/raysession/src/daemon/session.py", line 994, in adjust_files_after_copy
    client.read_xml_properties(XmlElement(client_xml))
  File "/usr/local/share/raysession/src/daemon/client.py", line 921, in read_xml_properties
    self.update_infos_from_desktop_file()
  File "/usr/local/share/raysession/src/daemon/client.py", line 1974, in update_infos_from_desktop_file
    self._set_infos_from_desktop_contents(contents)
  File "/usr/local/share/raysession/src/daemon/client.py", line 395, in _set_infos_from_desktop_contents
    lang_strs = ("[%s]" % lang[0:5], "[%s]" % lang[0:2], "")
                          ~~~~^^^^^
TypeError: 'NoneType' object is not subscriptable
```