### PR TITLE
Support pyliblo3 as well as liblo

### DIFF
--- a/src/clients/jackpatch/main_loop.py
+++ b/src/clients/jackpatch/main_loop.py
@@ -19,7 +19,10 @@
 import os
 import signal
 import sys
-import liblo
+try:
+    import liblo
+except ImportError:
+    import pyliblo3 as liblo
 import logging
 import xml.etree.ElementTree as ET
 

--- a/src/clients/sooperlooper/sooperlooper_lash
+++ b/src/clients/sooperlooper/sooperlooper_lash
@@ -7,7 +7,10 @@ import subprocess
 import time
 
 try:
-    import liblo
+    try:
+        import liblo
+    except ImportError:
+        import pyliblo3 as liblo
     import xml.etree.ElementTree as ET
     from signal import signal, SIGINT, SIGTERM, SIGUSR1, SIGUSR2
 except:

--- a/src/clients/sooperlooper/sooperlooper_nsm.py
+++ b/src/clients/sooperlooper/sooperlooper_nsm.py
@@ -5,7 +5,10 @@ import os
 import signal
 import sys
 
-from liblo import Address, make_method
+try:
+    from liblo import Address, make_method
+except ImportError:
+    from pyliblo3 import Address, make_method
 from PyQt5.QtCore import (QCoreApplication, pyqtSignal, QObject, QTimer,
                           QProcess)
 from PyQt5.QtXml import QDomDocument

--- a/src/control/osc_server.py
+++ b/src/control/osc_server.py
@@ -3,7 +3,10 @@ import os
 import sys
 import time
 
-import liblo
+try:
+    import liblo
+except ImportError:
+    import pyliblo3 as liblo
 
 # !!! we don't load ray.py to win import duration
 # if change in ray.Err numbers, this has to be changed too !!!

--- a/src/daemon/canvas_saver.py
+++ b/src/daemon/canvas_saver.py
@@ -4,7 +4,10 @@ import os
 import tempfile
 import time
 from typing import TYPE_CHECKING
-from liblo import Address
+try:
+    from liblo import Address
+except ImportError:
+    from pyliblo3 import Address
 
 import ray
 

--- a/src/daemon/client.py
+++ b/src/daemon/client.py
@@ -5,7 +5,10 @@ import shutil
 import signal
 import time
 from pathlib import Path
-from liblo import Address
+try:
+    from liblo import Address
+except ImportError:
+    from pyliblo3 import Address
 from PyQt5.QtCore import (QCoreApplication, QProcess,
                           QProcessEnvironment, QTimer)
 from PyQt5.QtXml import QDomDocument

--- a/src/daemon/daemon_tools.py
+++ b/src/daemon/daemon_tools.py
@@ -7,7 +7,10 @@ from pathlib import Path
 
 from PyQt5.QtCore import (QCoreApplication, QStandardPaths, QSettings,
                           QDateTime, QLocale)
-import liblo
+try:
+    import liblo
+except ImportError:
+    import pyliblo3 as liblo
 
 
 import ray

--- a/src/daemon/osc_server_thread.py
+++ b/src/daemon/osc_server_thread.py
@@ -10,7 +10,10 @@ from typing import TYPE_CHECKING
 from pathlib import Path
 import xml.etree.ElementTree as ET
 
-import liblo
+try:
+    import liblo
+except ImportError:
+    import pyliblo3 as liblo
 from PyQt5.QtCore import QCoreApplication
 
 import ray

--- a/src/daemon/session.py
+++ b/src/daemon/session.py
@@ -9,10 +9,16 @@ import subprocess
 import sys
 import time
 from typing import Callable, Optional, Any, Union
-from liblo import Address
+try:
+    from liblo import Address
+except ImportError:
+    from pyliblo3 import Address
 from PyQt5.QtCore import QCoreApplication, QTimer
 from PyQt5.QtXml  import QDomDocument
-import liblo
+try:
+    import liblo
+except ImportError:
+    import pyliblo3 as liblo
 from pathlib import Path
 import xml.etree.ElementTree as ET
 from io import BytesIO

--- a/src/daemon/session_signaled.py
+++ b/src/daemon/session_signaled.py
@@ -5,7 +5,10 @@ from pathlib import Path
 import subprocess
 import time
 from typing import TYPE_CHECKING
-from liblo import Address
+try:
+    from liblo import Address
+except ImportError:
+    from pyliblo3 import Address
 from PyQt5.QtCore import QCoreApplication, QProcess
 from PyQt5.QtXml  import QDomDocument
 

--- a/src/gui/daemon_manager.py
+++ b/src/gui/daemon_manager.py
@@ -6,7 +6,10 @@ import time
 from typing import TYPE_CHECKING
 from PyQt5.QtCore import QObject, QProcess, QTimer
 from PyQt5.QtWidgets import QApplication
-from liblo import Address
+try:
+    from liblo import Address
+except ImportError:
+    from pyliblo3 import Address
 
 import ray
 from gui_server_thread import GuiServerThread

--- a/src/gui/gui_server_thread.py
+++ b/src/gui/gui_server_thread.py
@@ -1,7 +1,10 @@
 import os
 import sys
 from typing import TYPE_CHECKING
-import liblo
+try:
+    import liblo
+except ImportError:
+    import pyliblo3 as liblo
 
 import ray
 from gui_tools import CommandLineArgs

--- a/src/gui/gui_signaler.py
+++ b/src/gui/gui_signaler.py
@@ -1,6 +1,9 @@
 import enum
 from PyQt5.QtCore import QObject, pyqtSignal
-from liblo import Address
+try:
+    from liblo import Address
+except ImportError:
+    from pyliblo3 import Address
 
 class Signaler(QObject):
     osc_receive = pyqtSignal(str, list)

--- a/src/gui/gui_tools.py
+++ b/src/gui/gui_tools.py
@@ -6,7 +6,10 @@ from typing import TYPE_CHECKING
 from PyQt5.QtCore import QSettings, QSize, QFile, QObject, pyqtSignal
 from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtGui import QIcon, QPixmap, QPalette
-from liblo import Address
+try:
+    from liblo import Address
+except ImportError:
+    from pyliblo3 import Address
 
 import ray
 

--- a/src/jack_patchbay_to_osc/osc_server.py
+++ b/src/jack_patchbay_to_osc/osc_server.py
@@ -6,7 +6,10 @@ import json
 import subprocess
 from typing import TYPE_CHECKING
 
-from liblo import Server, Address
+try:
+    from liblo import Server, Address
+except ImportError:
+    from pyliblo3 import Server, Address
 
 if TYPE_CHECKING:
     from ray_jackpatch_to_osc import MainObject, TransportPosition

--- a/src/shared/nsm_client.py
+++ b/src/shared/nsm_client.py
@@ -2,7 +2,10 @@
 
 from enum import IntEnum
 import os
-from liblo import Server, make_method, Address
+try:
+    from liblo import Server, make_method, Address
+except ImportError:
+    from pyliblo3 import Server, make_method, Address
 from typing import Callable, Optional
 
 

--- a/src/shared/nsm_client_qt.py
+++ b/src/shared/nsm_client_qt.py
@@ -3,7 +3,10 @@
 import os
 import sys
 from PyQt5.QtCore import QObject, pyqtSignal
-from liblo import ServerThread, make_method, Address
+try:
+    from liblo import ServerThread, make_method, Address
+except ImportError:
+    from pyliblo3 import ServerThread, make_method, Address
 from typing import Optional
 
 

--- a/src/shared/over_liblo.py
+++ b/src/shared/over_liblo.py
@@ -1,6 +1,10 @@
 
-import liblo
-from liblo import Message
+try:
+    import liblo
+    from liblo import Message
+except ImportError:
+    import pyliblo3 as liblo
+    from pyliblo3 import Message
 
 def make_method(*args, **kwargs):
     return liblo.make_method(*args, **kwargs)

--- a/src/shared/ray.py
+++ b/src/shared/ray.py
@@ -5,7 +5,10 @@ from asyncio.log import logger
 from dataclasses import dataclass
 from enum import IntEnum
 from typing import TYPE_CHECKING, Optional
-import liblo
+try:
+    import liblo
+except ImportError:
+    import pyliblo3 as liblo
 import os
 import shlex
 import socket
@@ -13,7 +16,10 @@ import subprocess
 import sys
 import logging
 
-from liblo import Server, Address
+try:
+    from liblo import Server, Address
+except ImportError:
+    from pyliblo3 import Server, Address
 from PyQt5.QtCore import QT_VERSION_STR, QSettings
 
 _logger = logging.getLogger(__name__)


### PR DESCRIPTION
pyliblo has not been touched upstream since 2015 and doesn't work out of the box with Python releases since 3.11. There is an actively-maintained fork called 'pyliblo3' at
https://github.com/gesellkammer/pyliblo3 which *does* work with current upstream Python releases. It provides a library called 'pyliblo3' rather than 'liblo'. Let's support it.

There are some odd cases of redundant importing here, but I decided not to 'fix' those, it could be done separately if wanted.